### PR TITLE
Add analytics module and webhook integration

### DIFF
--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from catanatron.models.enums import ActionType
+from catanatron.state_functions import (
+    player_key,
+    get_actual_victory_points,
+    player_num_resource_cards,
+    get_dev_cards_in_hand,
+    get_longest_road_color,
+    get_largest_army,
+)
+
+
+def _compress_players_state(game: Any) -> Dict[str, Any]:
+    state = game.state
+    result: Dict[str, Any] = {}
+    for color in state.colors:
+        key = player_key(state, color)
+        result[color.value] = {
+            "victory_points": get_actual_victory_points(state, color),
+            "resources": player_num_resource_cards(state, color),
+            "dev_cards": get_dev_cards_in_hand(state, color),
+            "roads_left": state.player_state[f"{key}_ROADS_AVAILABLE"],
+            "settlements_left": state.player_state[f"{key}_SETTLEMENTS_AVAILABLE"],
+            "cities_left": state.player_state[f"{key}_CITIES_AVAILABLE"],
+        }
+    return result
+
+
+def _describe_action(action) -> str:
+    typ = action.action_type
+    val = action.value
+    if typ == ActionType.BUILD_SETTLEMENT:
+        return f"Build settlement at {val}"
+    elif typ == ActionType.BUILD_CITY:
+        return f"Upgrade to city at {val}"
+    elif typ == ActionType.BUILD_ROAD:
+        return f"Build road between {val}"
+    elif typ == ActionType.BUY_DEVELOPMENT_CARD:
+        return "Buy development card"
+    elif typ == ActionType.END_TURN:
+        return "End current turn"
+    elif typ == ActionType.ROLL:
+        return "Roll"
+    else:
+        return typ.value
+
+
+def build_analytics(game: Any, my_color: Any, playable_actions: List) -> Dict[str, Any]:
+    """Return a lightweight analytics dictionary for the given state."""
+    players_state = _compress_players_state(game)
+    board = {
+        "robber": game.state.board.robber_coordinate,
+        "longest_road_color": get_longest_road_color(game.state),
+        "largest_army_color": get_largest_army(game.state)[0],
+    }
+    available = [
+        {
+            "type": a.action_type.value,
+            "value": a.value,
+            "description": _describe_action(a),
+        }
+        for a in playable_actions
+    ]
+    analytics = {
+        "players": players_state,
+        "board": board,
+        "available_actions": available,
+    }
+    return analytics

--- a/catanatron/catanatron/models/player.py
+++ b/catanatron/catanatron/models/player.py
@@ -4,6 +4,8 @@ import requests
 import os
 import time
 
+from catanatron.analytics import build_analytics
+
 from enum import Enum
 
 
@@ -104,11 +106,17 @@ class WebHookPlayer(Player):
         self.webhook_url = webhook_url
 
     def decide(self, game, playable_actions):
-        print(f"[WEBHOOK DECIDE] game_id={game.id} turn={game.state.num_turns} color={self.color} name={self.name} pid={os.getpid()} time={time.time()}")
+        print(
+            f"[WEBHOOK DECIDE] game_id={game.id} turn={game.state.num_turns} color={self.color} name={self.name} pid={os.getpid()} time={time.time()}"
+        )
         # Prepare data for webhook
         # Serialize game_state minimally for webhook (expand as needed)
         game_state = {
-            "current_color": game.state.current_color().value if hasattr(game.state.current_color(), 'value') else game.state.current_color(),
+            "current_color": (
+                game.state.current_color().value
+                if hasattr(game.state.current_color(), "value")
+                else game.state.current_color()
+            ),
             "current_prompt": str(game.state.current_prompt),
             "num_turns": game.state.num_turns,
             "actions_count": len(game.state.actions),
@@ -118,10 +126,15 @@ class WebHookPlayer(Player):
             "name": self.name,
             "game_id": game.id,
             "game_state": game_state,
+            "analytics": build_analytics(game, self.color, playable_actions),
             "actions": [
                 {
-                    "color": a.color.value if hasattr(a.color, 'value') else a.color,
-                    "action_type": a.action_type.value if hasattr(a.action_type, 'value') else a.action_type,
+                    "color": a.color.value if hasattr(a.color, "value") else a.color,
+                    "action_type": (
+                        a.action_type.value
+                        if hasattr(a.action_type, "value")
+                        else a.action_type
+                    ),
                     "value": a.value,
                 }
                 for a in playable_actions

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch, MagicMock
+
+from catanatron.analytics import build_analytics
+from catanatron.game import Game
+from catanatron.models.player import Color, SimplePlayer, WebHookPlayer
+
+
+def test_build_analytics_basic():
+    players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
+    game = Game(players)
+    actions = game.state.playable_actions
+    analytics = build_analytics(game, Color.RED, actions)
+    assert "players" in analytics
+    assert "board" in analytics
+    assert "available_actions" in analytics
+    assert len(analytics["available_actions"]) == len(actions)
+    assert analytics["players"][Color.RED.value]["victory_points"] >= 0
+
+
+def test_webhook_player_sends_analytics():
+    bot = WebHookPlayer(Color.RED, "http://example.com")
+    other = SimplePlayer(Color.BLUE)
+    game = Game([bot, other])
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"action_index": 0}
+    mock_resp.raise_for_status.return_value = None
+
+    with patch(
+        "catanatron.models.player.requests.post", return_value=mock_resp
+    ) as mock_post:
+        bot.decide(game, game.state.playable_actions)
+        assert mock_post.called
+        sent = mock_post.call_args.kwargs["json"]
+        assert "analytics" in sent
+        assert "available_actions" in sent["analytics"]


### PR DESCRIPTION
## Summary
- add `analytics.py` to compute lightweight game analytics
- include analytics payload in `WebHookPlayer`
- test analytics generation and webhook integration

## Testing
- `coverage run --source=catanatron -m pytest tests/` *(fails: test_play_strong)*
- `coverage report`
- `npm ci`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_686029d08100832c89764f96b06987c5