### PR TITLE
Add board analytics summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,15 +79,15 @@ This repository hosts **Catanatron**, a high–performance Settlers of Catan sim
 ## Roadmap
 
 1. **Create analytics module**
-   - [ ] Add `catanatron/catanatron/analytics.py` with `build_analytics(game, my_color, playable_actions)`
+   - [x] Add `catanatron/catanatron/analytics.py` with `build_analytics(game, my_color, playable_actions)`
 
 2. **Integrate analytics into WebHookPlayer**
-   - [ ] Add `analytics` field to the JSON sent to the webhook
+   - [x] Add `analytics` field to the JSON sent to the webhook
 
 3. **Implement basic analytics**
-   - [ ] Compressed player state (resources, VP, dev cards, buildings)
-   - [ ] Compressed opponents state
-   - [ ] Board summary (production, variety, robber, ports)
+   - [x] Compressed player state (resources, VP, dev cards, buildings)
+   - [x] Compressed opponents state
+   - [x] Board summary (production, variety, robber, ports)
    - [ ] Action evaluation (description, risk, strategic value)
    - [ ] Settlement/city recommendations (production, variety, port bonus)
    - [ ] Strategic hints (threat, position, discard risk)

--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any, Dict, List
 
-from catanatron.models.enums import ActionType
+from catanatron.models.enums import ActionType, SETTLEMENT, CITY
 from catanatron.state_functions import (
     player_key,
     get_actual_victory_points,
@@ -10,6 +11,7 @@ from catanatron.state_functions import (
     get_dev_cards_in_hand,
     get_longest_road_color,
     get_largest_army,
+    get_player_buildings,
 )
 
 
@@ -48,14 +50,52 @@ def _describe_action(action) -> str:
         return typ.value
 
 
+def _player_board_stats(game: Any, color) -> Dict[str, Any]:
+    """Return production, variety and accessible ports for a player."""
+    state = game.state
+    board = state.board
+    settlements = get_player_buildings(state, color, SETTLEMENT)
+    cities = get_player_buildings(state, color, CITY)
+    prod_counter: Counter = Counter()
+    variety = set()
+    for node_id in settlements:
+        prod_counter += board.map.node_production[node_id]
+        variety.update(board.map.node_production[node_id].keys())
+    for node_id in cities:
+        prod_counter += Counter(
+            {k: 2 * v for k, v in board.map.node_production[node_id].items()}
+        )
+        variety.update(board.map.node_production[node_id].keys())
+
+    accessible_ports = []
+    for res, nodes in board.map.port_nodes.items():
+        if any(n in nodes for n in settlements + cities):
+            accessible_ports.append(res.value if res else "3:1")
+
+    return {
+        "expected_production": sum(prod_counter.values()),
+        "resource_variety": len(variety),
+        "ports": sorted(accessible_ports),
+    }
+
+
+def _board_summary(game: Any) -> Dict[str, Any]:
+    summary = {
+        "robber": game.state.board.robber_coordinate,
+    }
+    per_player = {}
+    for color in game.state.colors:
+        per_player[color.value] = _player_board_stats(game, color)
+    summary["players"] = per_player
+    return summary
+
+
 def build_analytics(game: Any, my_color: Any, playable_actions: List) -> Dict[str, Any]:
     """Return a lightweight analytics dictionary for the given state."""
     players_state = _compress_players_state(game)
-    board = {
-        "robber": game.state.board.robber_coordinate,
-        "longest_road_color": get_longest_road_color(game.state),
-        "largest_army_color": get_largest_army(game.state)[0],
-    }
+    board = _board_summary(game)
+    board["longest_road_color"] = get_longest_road_color(game.state)
+    board["largest_army_color"] = get_largest_army(game.state)[0]
     available = [
         {
             "type": a.action_type.value,

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -15,6 +15,10 @@ def test_build_analytics_basic():
     assert "available_actions" in analytics
     assert len(analytics["available_actions"]) == len(actions)
     assert analytics["players"][Color.RED.value]["victory_points"] >= 0
+    # board summary should include robber and per-player info
+    assert "robber" in analytics["board"]
+    assert Color.RED.value in analytics["board"]["players"]
+    assert "expected_production" in analytics["board"]["players"][Color.RED.value]
 
 
 def test_webhook_player_sends_analytics():


### PR DESCRIPTION
## Summary
- track task progress in `AGENTS.md`
- extend analytics module with board summary and per-player stats
- adjust tests for new board summary

## Testing
- `pip install .[web,gym,dev]`
- `coverage run --source=catanatron -m pytest tests/`
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_b_68602eafd290832c99f77348d7de64ae