### PR TITLE
Fix port summary string

### DIFF
--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -70,7 +70,7 @@ def _player_board_stats(game: Any, color) -> Dict[str, Any]:
     accessible_ports = []
     for res, nodes in board.map.port_nodes.items():
         if any(n in nodes for n in settlements + cities):
-            accessible_ports.append(res.value if res else "3:1")
+            accessible_ports.append(res if res else "3:1")
 
     return {
         "expected_production": sum(prod_counter.values()),


### PR DESCRIPTION
## Summary
- fix string type from `FastResource` for ports

## Testing
- `coverage run --source=catanatron -m pytest tests/` *(fails: test_play_strong, test_csv_play)*
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_b_68603385fe94832caac71dc4cc4237de