### PR TITLE
Fix webhook error handling

### DIFF
--- a/catanatron/catanatron/game.py
+++ b/catanatron/catanatron/game.py
@@ -213,6 +213,7 @@ def acquire_lock(game_id, timeout=LOCK_TIMEOUT):
     print(f"[LOCK ACQUIRED] {game_id} pid={os.getpid()} time={time.time()}")
     return lockfile
 
+
 def release_lock(lockfile):
     if os.path.exists(lockfile):
         os.remove(lockfile)

--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -77,7 +77,9 @@ class GameEncoder(json.JSONEncoder):
                         "direction": self.default(direction),
                         "color": self.default(color),
                     }
-            player_names = {p.color.value: p.name for p in getattr(obj.state, 'players', [])}
+            player_names = {
+                p.color.value: p.name for p in getattr(obj.state, "players", [])
+            }
             return {
                 "tiles": [
                     {"coordinate": coordinate, "tile": self.default(tile)}

--- a/catanatron/catanatron/models/player.py
+++ b/catanatron/catanatron/models/player.py
@@ -151,7 +151,7 @@ class WebHookPlayer(Player):
                 return playable_actions[0]
         except Exception as e:
             print(f"WebHookPlayer({self.name}): Error: {e}")
-            return playable_actions[0]
+            raise
 
     def __repr__(self):
         return f"WebHookPlayer({self.name}):{self.color.value}"

--- a/catanatron/catanatron/players/value.py
+++ b/catanatron/catanatron/players/value.py
@@ -149,7 +149,13 @@ class ValueFunctionPlayer(Player):
     """
 
     def __init__(
-        self, color, value_fn_builder_name=None, params=None, is_bot=True, epsilon=None, name=None
+        self,
+        color,
+        value_fn_builder_name=None,
+        params=None,
+        is_bot=True,
+        epsilon=None,
+        name=None,
     ):
         super().__init__(color, is_bot, name=name)
         self.value_fn_builder_name = (

--- a/tests/test_analytics_ports.py
+++ b/tests/test_analytics_ports.py
@@ -1,0 +1,16 @@
+from catanatron.analytics import build_analytics
+from catanatron.game import Game
+from catanatron.models.player import Color, SimplePlayer
+from catanatron.state_functions import build_settlement
+
+
+def test_port_summary_from_building():
+    players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
+    game = Game(players)
+    res, nodes = next(iter(game.state.board.map.port_nodes.items()))
+    node = next(iter(nodes))
+    game.state.board.build_settlement(Color.RED, node, initial_build_phase=True)
+    build_settlement(game.state, Color.RED, node, True)
+    analytics = build_analytics(game, Color.RED, game.state.playable_actions)
+    ports = analytics["board"]["players"][Color.RED.value]["ports"]
+    assert ports and (res if res else "3:1") in ports


### PR DESCRIPTION
## Summary
- raise exceptions in `WebHookPlayer.decide` instead of returning the first action
- test that webhook errors are propagated
- ensure ports are extracted as plain strings
- add regression test for building on ports
- format repo with `black`

## Testing
- `pytest tests/test_analytics.py::test_webhook_player_raises_on_error -q`
- `pytest tests/test_analytics_ports.py -q`
- `coverage run --source=catanatron -m pytest tests/` *(fails: tests/integration_tests/test_play.py::test_play_strong)*
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_b_6860361b5a64832cb4cdb87741b5644d