### PR TITLE
Enhance analytics

### DIFF
--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -20,13 +20,22 @@ def _compress_players_state(game: Any) -> Dict[str, Any]:
     result: Dict[str, Any] = {}
     for color in state.colors:
         key = player_key(state, color)
+        victory_points = get_actual_victory_points(state, color)
+        resources = player_num_resource_cards(state, color)
         result[color.value] = {
-            "victory_points": get_actual_victory_points(state, color),
-            "resources": player_num_resource_cards(state, color),
+            "victory_points": victory_points,
+            "resources": resources,
             "dev_cards": get_dev_cards_in_hand(state, color),
             "roads_left": state.player_state[f"{key}_ROADS_AVAILABLE"],
             "settlements_left": state.player_state[f"{key}_SETTLEMENTS_AVAILABLE"],
             "cities_left": state.player_state[f"{key}_CITIES_AVAILABLE"],
+            "resources_count": resources,
+            "threat_level": (
+                "HIGH"
+                if victory_points >= 8
+                else "MEDIUM" if victory_points >= 6 else "LOW"
+            ),
+            "has_largest_army": state.player_state.get(f"{key}_HAS_ARMY", False),
         }
     return result
 
@@ -48,6 +57,37 @@ def _describe_action(action) -> str:
         return "Roll"
     else:
         return typ.value
+
+
+def _evaluate_action(action) -> Dict[str, Any]:
+    """Return a description, strategic value and risk for an action."""
+    typ = action.action_type
+    val = action.value
+    desc = _describe_action(action)
+    strategic_value = "neutral"
+    risk = "low"
+
+    if typ == ActionType.ROLL:
+        desc = "Roll dice to get resources"
+        risk = "medium"
+    elif typ == ActionType.BUILD_SETTLEMENT:
+        strategic_value = "high"
+    elif typ == ActionType.BUILD_CITY:
+        strategic_value = "very_high"
+    elif typ == ActionType.BUILD_ROAD:
+        strategic_value = "medium"
+    elif typ == ActionType.BUY_DEVELOPMENT_CARD:
+        strategic_value = "medium"
+    elif typ == ActionType.END_TURN:
+        strategic_value = "low"
+
+    return {
+        "type": typ.value,
+        "value": val,
+        "description": desc,
+        "strategic_value": strategic_value,
+        "risk_level": risk,
+    }
 
 
 def _player_board_stats(game: Any, color) -> Dict[str, Any]:
@@ -96,14 +136,7 @@ def build_analytics(game: Any, my_color: Any, playable_actions: List) -> Dict[st
     board = _board_summary(game)
     board["longest_road_color"] = get_longest_road_color(game.state)
     board["largest_army_color"] = get_largest_army(game.state)[0]
-    available = [
-        {
-            "type": a.action_type.value,
-            "value": a.value,
-            "description": _describe_action(a),
-        }
-        for a in playable_actions
-    ]
+    available = [_evaluate_action(a) for a in playable_actions]
     analytics = {
         "players": players_state,
         "board": board,

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -21,6 +21,11 @@ def test_build_analytics_basic():
     assert "robber" in analytics["board"]
     assert Color.RED.value in analytics["board"]["players"]
     assert "expected_production" in analytics["board"]["players"][Color.RED.value]
+    assert "resources_count" in analytics["players"][Color.RED.value]
+    assert "threat_level" in analytics["players"][Color.RED.value]
+    first_action = analytics["available_actions"][0]
+    assert "risk_level" in first_action
+    assert "strategic_value" in first_action
 
 
 def test_webhook_player_sends_analytics():


### PR DESCRIPTION
## Summary
- expand analytics: add threat level, resources count and largest army flag per player
- evaluate actions with strategic value and risk level
- test analytics for new fields

## Testing
- `coverage run --source=catanatron -m pytest -k "not integration_tests" tests/`
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_b_686047c1c684832c94cc4edfe95d2ae4