### PR TITLE
Add building recommendations to analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,9 @@ This repository hosts **Catanatron**, a high–performance Settlers of Catan sim
    - [x] Compressed player state (resources, VP, dev cards, buildings)
    - [x] Compressed opponents state
    - [x] Board summary (production, variety, robber, ports)
-   - [ ] Action evaluation (description, risk, strategic value)
-   - [ ] Settlement/city recommendations (production, variety, port bonus)
-   - [ ] Strategic hints (threat, position, discard risk)
+  - [x] Action evaluation (description, risk, strategic value)
+  - [x] Settlement/city recommendations (production, variety, port bonus)
+  - [ ] Strategic hints (threat, position, discard risk)
 
 4. **Add AI/bot recommendations**
    - [ ] Call AlphaBeta/MCTS at depth 1-2 for action evaluation

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -75,3 +75,16 @@ def test_webhook_player_raises_on_error():
     ) as mock_post:
         with pytest.raises(requests.exceptions.Timeout):
             bot.decide(game, game.state.playable_actions)
+
+
+def test_settlement_and_city_recommendations():
+    players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
+    game = Game(players)
+    analytics = build_analytics(game, Color.RED, game.state.playable_actions)
+    assert "settlement_recommendations" in analytics
+    rec = analytics["settlement_recommendations"]
+    assert "best_positions" in rec
+    assert "analysis" in rec
+    assert "city_recommendations" in analytics
+    city = analytics["city_recommendations"]
+    assert "best_upgrades" in city


### PR DESCRIPTION
## Summary
- implement settlement and city recommendation analytics
- mark roadmap tasks for completed analytics features
- test new fields in `build_analytics`

## Testing
- `black catanatron catanatron_experimental`
- `coverage run --source=catanatron -m pytest tests/` *(fails: Timeout waiting for lock)*
- `coverage run --source=catanatron -m pytest tests/integration_tests/test_play.py::test_play_strong -vv` *(fails: Timeout waiting for lock)*


------
https://chatgpt.com/codex/tasks/task_b_68604e30ff00832cbf43a08c12c6998c