### PR TITLE
Fix webhook error handling to keep game going

### DIFF
--- a/catanatron/catanatron/game.py
+++ b/catanatron/catanatron/game.py
@@ -134,7 +134,10 @@ class Game:
         for accumulator in accumulators:
             accumulator.before(self)
         while self.winning_color() is None and self.state.num_turns < TURNS_LIMIT:
-            self.play_tick(decide_fn=decide_fn, accumulators=accumulators)
+            try:
+                self.play_tick(decide_fn=decide_fn, accumulators=accumulators)
+            except Exception as e:
+                print(f"[GAME ERROR] {e}")
         for accumulator in accumulators:
             accumulator.after(self)
         return self.winning_color()

--- a/catanatron/catanatron/models/player.py
+++ b/catanatron/catanatron/models/player.py
@@ -150,8 +150,11 @@ class WebHookPlayer(Player):
             else:
                 return playable_actions[0]
         except Exception as e:
-            print(f"WebHookPlayer({self.name}): Error: {e}")
-            raise
+            print(
+                f"WebHookPlayer({self.name}): Error: {e}."
+                " Falling back to first playable action."
+            )
+            return playable_actions[0]
 
     def __repr__(self):
         return f"WebHookPlayer({self.name}):{self.color.value}"


### PR DESCRIPTION
## Summary
- catch errors in `play()` so game loop doesn't abort
- fall back to the first playable action when webhook calls fail

## Testing
- `coverage run --source=catanatron -m pytest tests/` *(fails: test_play_strong)*
- `coverage report`
- `npm ci` *(fails: unsupported engine)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68604df8499c832cba21fd52d30ccb24