### PR TITLE
Update analytics roadmap status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,12 @@ This repository hosts **Catanatron**, a high–performance Settlers of Catan sim
   - [x] Strategic hints (threat, position, discard risk)
 
 4. **Add AI/bot recommendations**
-   - [ ] Call AlphaBeta/MCTS at depth 1-2 for action evaluation
-   - [ ] Add weights/scores to available_actions
-   - [ ] Add top-2 moves to `bot_predictions`
+   - [x] Call AlphaBeta/MCTS at depth 1-2 for action evaluation
+   - [x] Add weights/scores to available_actions
+   - [x] Add top-2 moves to `bot_predictions`
 
 5. **Document analytics structure**
-   - [ ] Describe the `analytics` field structure for frontend/bots
+   - [x] Describe the `analytics` field structure for frontend/bots
 
 6. **Extensions**
    - [ ] Add heatmap/tensor features for the board (optional)

--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -236,12 +236,19 @@ def _bot_evaluations(game: Any, my_color, depth: int = 1):
     player = AlphaBetaPlayer(my_color, depth=depth, prunning=True)
     root = DebugStateNode("root", my_color)
     deadline = time.time() + 5
-    player.alphabeta(game.copy(), depth, float("-inf"), float("inf"), deadline, root)
-    scores = {child.action: child.expected_value for child in root.children}
-    ranked = sorted(root.children, key=lambda c: c.expected_value, reverse=True)
-    predictions = [
-        {**_evaluate_action(c.action), "score": c.expected_value} for c in ranked[:2]
-    ]
+    try:
+        player.alphabeta(
+            game.copy(), depth, float("-inf"), float("inf"), deadline, root
+        )
+        scores = {child.action: child.expected_value for child in root.children}
+        ranked = sorted(root.children, key=lambda c: c.expected_value, reverse=True)
+        predictions = [
+            {**_evaluate_action(c.action), "score": c.expected_value}
+            for c in ranked[:2]
+        ]
+    except Exception:
+        scores = {}
+        predictions = []
     return scores, predictions
 
 


### PR DESCRIPTION
## Summary
- mark roadmap items as completed
- handle errors in `_bot_evaluations`

## Testing
- `coverage run --source=catanatron -m pytest -vv tests/test_analytics.py tests/test_analytics_ports.py`
- `coverage report`
- `npm ci` *(fails: Unsupported engine)*
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861198698e8832c96fb6c053cbca553