### PR TITLE
Add board tensor analytics

### DIFF
--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from typing import Any, Dict, List
+
 import time
 
 from catanatron.models.enums import ActionType, SETTLEMENT, CITY
@@ -130,6 +131,14 @@ def _board_summary(game: Any) -> Dict[str, Any]:
         per_player[color.value] = _player_board_stats(game, color)
     summary["players"] = per_player
     return summary
+
+
+def _board_tensor(game: Any, color) -> List[List[List[float]]]:
+    """Return board tensor as nested lists for JSON serialization."""
+    from catanatron.gym.board_tensor_features import create_board_tensor
+
+    tensor = create_board_tensor(game, color)
+    return tensor.tolist()
 
 
 def _score_node(board, node_id, city=False) -> Dict[str, Any]:
@@ -268,6 +277,7 @@ def build_analytics(game: Any, my_color: Any, playable_actions: List) -> Dict[st
     analytics = {
         "players": players_state,
         "board": board,
+        "board_tensor": _board_tensor(game, my_color),
         "available_actions": available,
         "settlement_recommendations": _settlement_recommendations(game, my_color),
         "city_recommendations": _city_recommendations(game, my_color),

--- a/docs/source/analytics.rst
+++ b/docs/source/analytics.rst
@@ -17,6 +17,9 @@ these top‑level keys:
 ``board``
     Global board information. Includes robber position, player production stats
     and which player holds the longest road or largest army.
+``board_tensor``
+    3‑D matrix representing the board state as used for machine learning
+    experiments. The tensor is returned as nested lists.
 ``available_actions``
     List of the playable actions for the current turn. Each action description
     contains a human readable ``description``, ``strategic_value``, ``risk_level``
@@ -56,6 +59,7 @@ An abbreviated example of the analytics payload::
                 }
             }
         },
+        "board_tensor": [[...]],
         "available_actions": [
             {
                 "type": "ROLL",

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -14,6 +14,7 @@ def test_build_analytics_basic():
     analytics = build_analytics(game, Color.RED, actions)
     assert "players" in analytics
     assert "board" in analytics
+    assert "board_tensor" in analytics
     assert "available_actions" in analytics
     assert len(analytics["available_actions"]) == len(actions)
     assert analytics["players"][Color.RED.value]["victory_points"] >= 0
@@ -50,6 +51,7 @@ def test_webhook_player_sends_analytics():
         assert mock_post.called
         sent = mock_post.call_args.kwargs["json"]
         assert "analytics" in sent
+        assert "board_tensor" in sent["analytics"]
         assert "available_actions" in sent["analytics"]
 
 
@@ -88,6 +90,7 @@ def test_settlement_and_city_recommendations():
     players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
     game = Game(players)
     analytics = build_analytics(game, Color.RED, game.state.playable_actions)
+    assert "board_tensor" in analytics
     assert "settlement_recommendations" in analytics
     rec = analytics["settlement_recommendations"]
     assert "best_positions" in rec


### PR DESCRIPTION
## Summary
- include board tensor in analytics output
- document `board_tensor` field
- test board tensor in analytics

## Testing
- `coverage run --source=catanatron -m pytest tests/` *(fails: test_play_strong exited with code 1)*
- `coverage report`
- `npm ci` *(fails: unsupported engine)*
- `npm run test` *(fails: vitest not found)*
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_b_68611de50848832c9cf57b933ec46c8b