### PR TITLE
Fix DB connection issues with pre-ping

### DIFF
--- a/catanatron/catanatron/web/__init__.py
+++ b/catanatron/catanatron/web/__init__.py
@@ -18,6 +18,7 @@ def create_app(test_config=None):
         SECRET_KEY=secret_key,
         SQLALCHEMY_DATABASE_URI=database_url,
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        SQLALCHEMY_ENGINE_OPTIONS={"pool_pre_ping": True},
     )
     if test_config is not None:
         app.config.update(test_config)


### PR DESCRIPTION
## Summary
- ensure SQLAlchemy connections are checked before reuse

## Testing
- `pip install .[web,gym,dev]`
- `coverage run --source=catanatron -m pytest tests/` *(fails: NameError in analytics)*

------
https://chatgpt.com/codex/tasks/task_b_6864132da454832ca0337eb649a9267c