### PR TITLE
Fix optional board tensor dependency

### DIFF
--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -135,7 +135,10 @@ def _board_summary(game: Any) -> Dict[str, Any]:
 
 def _board_tensor(game: Any, color) -> List[List[List[float]]]:
     """Return board tensor as nested lists for JSON serialization."""
-    from catanatron.gym.board_tensor_features import create_board_tensor
+    try:
+        from catanatron.gym.board_tensor_features import create_board_tensor
+    except ModuleNotFoundError:  # gym extras not installed
+        return []
 
     tensor = create_board_tensor(game, color)
     return tensor.tolist()

--- a/catanatron/catanatron/gym/__init__.py
+++ b/catanatron/catanatron/gym/__init__.py
@@ -1,6 +1,12 @@
-from gymnasium.envs.registration import register
+"""Optional Gymnasium environment registration."""
 
-register(
-    id="catanatron/Catanatron-v0",
-    entry_point="catanatron.gym.envs:CatanatronEnv",
-)
+try:
+    from gymnasium.envs.registration import register
+except ModuleNotFoundError:  # pragma: no cover - gymnasium optional
+    register = None
+
+if register:
+    register(
+        id="catanatron/Catanatron-v0",
+        entry_point="catanatron.gym.envs:CatanatronEnv",
+    )


### PR DESCRIPTION
## Summary
- make catanatron.gym initialization resilient when gymnasium isn't installed
- return empty board tensor if gym extras aren't present

## Testing
- `coverage run --source=catanatron -m pytest tests/` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_6864190437cc832ca355205cd89738f9