### PR TITLE
Fix missing function import in analytics

### DIFF
--- a/catanatron/catanatron/analytics.py
+++ b/catanatron/catanatron/analytics.py
@@ -14,6 +14,7 @@ from catanatron.state_functions import (
     get_longest_road_color,
     get_longest_road_length,
     get_largest_army,
+    get_played_dev_cards,
     get_player_buildings,
 )
 from catanatron.models.map import number_probability


### PR DESCRIPTION
## Summary
- fix NameError in `_advanced_hints`

## Testing
- `coverage run --source=catanatron -m pytest tests/` *(fails: AssertionError in integration tests)*
- `coverage report`
- `npm ci` *(fails: unsupported Node version)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686559229750832c84e4fa6574e90603